### PR TITLE
fix: Fix LinkedList.pop method to handle single node lists

### DIFF
--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -6,8 +6,8 @@ class LinkedList
   end
 
   def append(data)
-    # Safety clause for non-string data
-    return if !data.is_a?(String)
+    # Guard clause for non-string data
+    return unless data.is_a?(String)
 
     node = Node.new(data)
 

--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -31,15 +31,17 @@ class LinkedList
   end
 
   def count
-    0 if @head.nil?
-    
-    counter = 1
-    node = @head
-    until node.next_node.nil?
-      counter += 1
-      node = node.next_node
+    if @head.nil?
+      0
+    else
+      counter = 1
+      node = @head
+      until node.next_node.nil?
+        counter += 1
+        node = node.next_node
+      end
+      counter
     end
-    counter
   end
 
   def to_string
@@ -105,14 +107,23 @@ class LinkedList
 
   def pop
     return if @head.nil?
-    @head = nil if @head.next_node.nil?
-    
-    node = @head
-    until node.next_node.next_node.nil?
-      node = node.next_node
+
+    popped = @head
+
+    if @head.next_node.nil?
+      @head = nil
+      popped
+    else
+      node = @head
+
+      until node.next_node.next_node.nil?
+        node = node.next_node
+      end
+
+      popped = node.next_node
+      node.update_next(nil)
+      
+      popped
     end
-    popped = node.next_node
-    node.update_next(nil)
-    popped
   end
 end

--- a/spec/linked_list_spec.rb
+++ b/spec/linked_list_spec.rb
@@ -124,7 +124,6 @@ describe LinkedList do
 
   it "can remove the last element from the list" do
     list = LinkedList.new
-    list.append("deep")
     list.append("woo")
     list.append("shi")
     list.append("shu")
@@ -132,6 +131,15 @@ describe LinkedList do
     list.pop
     list.pop
 
-    expect(list.to_string).to eq("deep woo shi")
+    expect(list.to_string).to eq("woo shi")
+  end
+
+  it "can pop a 1 node long list" do
+    list = LinkedList.new
+    list.append("woo")
+
+    expect(list.count).to eq(1)
+    list.pop
+    expect(list.count).to eq(0)
   end
 end


### PR DESCRIPTION
In this PR, I refactored one or two lines of code (which is why the branch is named `refactoring`. However, once I started doing tests, I noticed that my `pop` method couldn't handle lists 1 node long. I fixed that method to handle 1 node long lists.

All of this happened before our Git and Github lesson (Mon, 5/15/23), which is why the naming isn't consistent. However, moving forward, I will follow the branch naming conventions for new changes and fixes.