### PR TITLE
Refactor: beat_box_spec tests

### DIFF
--- a/spec/beat_box_spec.rb
+++ b/spec/beat_box_spec.rb
@@ -8,43 +8,98 @@ describe BeatBox do
     @bb = BeatBox.new
   end
 
-  it "exists" do
-    @expect(bb).to be_a(BeatBox)
+  context "#initialize" do
+    it "exists" do
+      expect(@bb).to be_a(BeatBox)
+    end
+
+    it "initializes an empty LinkedList by default" do
+      expect(@bb.list).to be_a(LinkedList)
+      expect(@bb.list.head).to be nil
+    end
+
+    it "can initialize with a single beat" do
+      @bb = BeatBox.new("deep")
+  
+      expect(@bb.count).to eq(1)
+    end
+
+    it "can initlaize with multiple beats" do
+      @bb = BeatBox.new("deep doo")
+  
+      expect(@bb.count).to eq(2)
+    end
   end
 
-  it "creates an empty LinkedList item on initialization" do
-    expect(@bb.list).to be_a(LinkedList)
-    expect(@bb.list.head).to be nil
-  end
-
-  it "can append multiple nodes at a time" do
-    @bb.append("deep doo ditt")
+  context "#append" do
+    it "can append a single beat" do
+      @bb.append("deep")
+      
+      expect(@bb.list.head.data).to eq("deep")
+      expect(@bb.list.head.next_node).to be nil
+      expect(@bb.count).to eq(1)
+      expect(@bb.all).to eq("deep")
+    end
     
-    expect(@bb.list.head.data).to eq("deep")
-    expect(@bb.list.head.next_node.data).to eq("doo")
+    it "can append multiple beats at once" do
+      @bb.append("deep doo ditt")
+      
+      expect(@bb.list.head.data).to eq("deep")
+      expect(@bb.list.head.next_node.data).to eq("doo")
+      expect(@bb.count).to eq(3)
+      expect(@bb.all).to eq("deep doo ditt")
+    end
+
+    it "will only append beats from a String" do
+      @bb.append(:deep)
+
+      expect(@bb.list.head).to be nil
+      expect(@bb.count).to eq(0)
+    end
   end
 
-  it "can count the number of nodes" do
-    @bb.append("deep doo ditt")
+  context "#count" do
+    it "can count the number of nodes" do
+      @bb.append("deep doo ditt")
 
-    expect(@bb.count).to eq(3)
+      expect(@bb.count).to eq(3)
 
-    @bb.append("woo hoo shu")
+      @bb.append("woo hoo shu")
 
-    expect(@bb.count).to eq(6)
+      expect(@bb.count).to eq(6)
+    end
+
+    it "can count an empty LinkedList" do
+      expect(@bb.count).to eq(0)
+    end
+    
+    it "can count a single node" do
+      @bb.append("deep")
+
+      expect(@bb.count).to eq(1)
+    end
   end
 
-  it "can play beats" do
-    @bb.append("deep doo ditt")
+  context "#play" do
+    it "can play beat sounds and not raise an error" do
+      expect { @bb.play }.not_to raise_error
+      
+      @bb.append("deep doo ditt")
+      
+      expect { @bb.play }.not_to raise_error
+    end
 
-    expect(@bb.play).to eq(3)
+    it "will not play an empty LinkedList" do
+      expect(@bb.play).to be nil
+    end
+
+    it "can play a multiple beats" do
+      @bb.append("deep doo ditt")
+
+      expect(@bb.play).to eq(3)
+    end
   end
-
-  it "can add beats on initialization" do
-    bb = BeatBox.new("deep")
-
-    expect(bb.count).to eq(1)
-  end
+  
 
   it "can return all current beats" do
     bb = BeatBox.new("deep")
@@ -79,7 +134,7 @@ describe BeatBox do
     expect(bb.rate).to eq(100)
   end
 
-  it "has a default voice of Boing" do
+  it "uses Boing as a default voice" do
     bb = BeatBox.new("deep dop dop deep")
 
     expect(bb.voice).to eq("Boing")

--- a/spec/beat_box_spec.rb
+++ b/spec/beat_box_spec.rb
@@ -100,72 +100,105 @@ describe BeatBox do
     end
   end
   
+  context "#all" do
+    it "can return a string of current beats" do
+      @bb.append("deep doo ditt")
 
-  it "can return all current beats" do
-    bb = BeatBox.new("deep")
+      expect(@bb.all).to eq("deep doo ditt")
+    end
 
-    expect(bb.all).to eq("deep")
+    it "can return a string of a single beat" do
+      @bb.append("deep")
+      
+      expect(@bb.all).to eq("deep")
+    end
+
+    it "will return nothing for an empty LinkedList" do
+      expect(@bb.all).to be nil
+    end
   end
 
-  it "can validate beats" do
-    bb = BeatBox.new("deep")
-    bb.append("Mississippi")
+  context "#validate_beats" do
+    it "has a list of valid beats" do
+      expect(@bb.valid_beats).to eq(%w[tee dee deep bop boop la na doo ditt woo hoo shu])
+    end
 
-    expect(bb.all).to eq("deep")
+    it "can validate a beat" do
+      expect(@bb.validate_beat("deep")).to be true
+      expect(@bb.validate_beat("Mississippi")).to be false
+    end
+
+    it "will only append valid beats" do
+      @bb.append("deep Mississippi")
+
+      expect(@bb.all).to eq("deep")
+    end
   end
 
-  it "can prepend beats" do
-    bb = BeatBox.new("deep")
-    bb.prepend("tee tee tee")
+  context "#prepend" do
+    it "can prepend beats to an existing LinkedList" do
+      @bb.append("deep")
 
-    expect(bb.all).to eq("tee tee tee deep")
+      expect(@bb.all).to eq("deep")
+      expect(@bb.count).to eq(1)
+      
+      @bb.prepend("tee tee tee")
+      
+      expect(@bb.all).to eq("tee tee tee deep")
+      expect(@bb.count).to eq(4)
+    end
+
+    it "can prepend beats to an empty LinkedList" do
+      @bb.prepend("tee tee tee")
+      
+      expect(@bb.all).to eq("tee tee tee")
+      expect(@bb.count).to eq(3)
+    end
   end
 
-  it "has a default playback rate of 500" do
-    bb = BeatBox.new("deep dop dop deep")
+  context "playback rate" do
+    it "has a default playback rate of 500" do
+      expect(@bb.rate).to eq(500)
+    end
 
-    expect(bb.rate).to eq(500)
+    it "can change its playback rate" do
+      @bb.rate = 100
+      
+      expect(@bb.rate).to eq(100)
+    end
+
+    it "can reset the playback rate to 500" do
+      @bb.rate = 100
+      
+      expect(@bb.rate).to eq(100)
+      
+      @bb.reset_rate
+      
+      expect(@bb.rate).to eq(500)
+    end
   end
+
   
-  it "can change playback rate" do
-    bb = BeatBox.new("deep dop dop deep")
-    bb.rate = 100
-    
-    expect(bb.rate).to eq(100)
-  end
 
-  it "uses Boing as a default voice" do
-    bb = BeatBox.new("deep dop dop deep")
+  context "playback voice" do
+    it "uses Boing as a default voice" do
+      expect(@bb.voice).to eq("Boing")
+    end
 
-    expect(bb.voice).to eq("Boing")
-  end
+    it "can change voices" do
+      @bb.voice = "Daniel"
   
-  it "can change voices" do
-    bb = BeatBox.new("deep dop dop deep")
-    bb.voice = "Daniel"
+      expect(@bb.voice).to eq("Daniel")
+    end
 
-    expect(bb.voice).to eq("Daniel")
-  end
+    it "can reset the voice" do
+      @bb.voice = "Daniel"
+    
+      expect(@bb.voice).to eq("Daniel")
   
-  it "can reset the playback rate" do
-    bb = BeatBox.new("deep dop dop deep")
-    bb.rate = 100
-    
-    expect(bb.rate).to eq(100)
-    
-    bb.reset_rate
-    
-    expect(bb.rate).to eq(500)
-  end
-
-  it "can reset the voice" do
-    bb = BeatBox.new("deep dop dop deep")
-    bb.voice = "Daniel"
+      @bb.reset_voice
   
-    expect(bb.voice).to eq("Daniel")
-
-    bb.reset_voice
-
-    expect(bb.voice).to eq("Boing")
+      expect(@bb.voice).to eq("Boing")
+    end
   end
 end

--- a/spec/beat_box_spec.rb
+++ b/spec/beat_box_spec.rb
@@ -4,6 +4,10 @@ require "./lib/node"
 require "rspec"
 
 describe BeatBox do
+  before(:each) do
+    @bb = BeatBox.new
+  end
+  
   it "exists" do
     bb = BeatBox.new
 

--- a/spec/beat_box_spec.rb
+++ b/spec/beat_box_spec.rb
@@ -7,44 +7,37 @@ describe BeatBox do
   before(:each) do
     @bb = BeatBox.new
   end
-  
-  it "exists" do
-    bb = BeatBox.new
 
-    expect(bb).to be_a(BeatBox)
+  it "exists" do
+    @expect(bb).to be_a(BeatBox)
   end
 
   it "creates an empty LinkedList item on initialization" do
-    bb = BeatBox.new
-
-    expect(bb.list).to be_a(LinkedList)
-    expect(bb.list.head).to be nil
+    expect(@bb.list).to be_a(LinkedList)
+    expect(@bb.list.head).to be nil
   end
 
   it "can append multiple nodes at a time" do
-    bb = BeatBox.new
-    bb.append("deep doo ditt")
+    @bb.append("deep doo ditt")
     
-    expect(bb.list.head.data).to eq("deep")
-    expect(bb.list.head.next_node.data).to eq("doo")
+    expect(@bb.list.head.data).to eq("deep")
+    expect(@bb.list.head.next_node.data).to eq("doo")
   end
 
   it "can count the number of nodes" do
-    bb = BeatBox.new
-    bb.append("deep doo ditt")
+    @bb.append("deep doo ditt")
 
-    expect(bb.count).to eq(3)
+    expect(@bb.count).to eq(3)
 
-    bb.append("woo hoo shu")
+    @bb.append("woo hoo shu")
 
-    expect(bb.count).to eq(6)
+    expect(@bb.count).to eq(6)
   end
 
   it "can play beats" do
-    bb = BeatBox.new
-    bb.append("deep doo ditt")
+    @bb.append("deep doo ditt")
 
-    expect(bb.play).to eq(3)
+    expect(@bb.play).to eq(3)
   end
 
   it "can add beats on initialization" do


### PR DESCRIPTION
In this branch, I reorganized a lot of the beat_box_spec tests. I put them into different contexts, so it looks very pretty and clear when you run the command `rspec --format doc spec/beat_box_spec.rb`. I didn't have enough time to do this for the rest of my tests for other classes, because I was learning on the fly, but I will do this for future development now that I understand branches and tests better.