### PR TITLE
fix: fix play method to return nil when list is empty

### DIFF
--- a/lib/beat_box.rb
+++ b/lib/beat_box.rb
@@ -24,6 +24,7 @@ class BeatBox
   end
 
   def play
+    return if @list.head.nil?
     `say -r #{@rate} -v #{@voice} #{all}`
     count
   end


### PR DESCRIPTION
this fixed an issue that would occur if someone tried to play a BeatBox when it was empty.